### PR TITLE
Remove `Logger.writeBytes` to ensure compatibility with java 8

### DIFF
--- a/src/nl/bramstout/mcworldexporter/Logger.java
+++ b/src/nl/bramstout/mcworldexporter/Logger.java
@@ -64,12 +64,6 @@ public class Logger extends PrintStream{
 	}
 	
 	@Override
-	public void writeBytes(byte[] buf) {
-		super.writeBytes(buf);
-		consoleOut.writeBytes(buf);
-	}
-	
-	@Override
 	public void println() {
 		super.println();
 		consoleOut.println();


### PR DESCRIPTION
Ran into a build error when trying to compile with java-8 runtime compatibility (Since it's mentioned in #9). Logger.writeBytes was introduced in Java 14, so I removed it.