### PR TITLE
fix: Handle edge cases with version paths

### DIFF
--- a/src/nl/bramstout/mcworldexporter/resourcepack/ResourcePack.java
+++ b/src/nl/bramstout/mcworldexporter/resourcepack/ResourcePack.java
@@ -334,9 +334,12 @@ public class ResourcePack {
 		if(new File(versionJar).exists())
 			return versionJar;
 		// If the jar doesn't exist, just pick the first jar file in the versions folder.
-		for(File f : new File(versionFolder).listFiles()) {
-			if(f.getName().endsWith(".jar"))
-				return f.getPath();
+		File[] versionFolderFiles = new File(versionFolder).listFiles();
+		if (versionFolderFiles != null) {
+			for(File f : versionFolderFiles) {
+				if(f.getName().endsWith(".jar"))
+					return f.getPath();
+			}
 		}
 		return null;
 	}
@@ -364,10 +367,17 @@ public class ResourcePack {
 				// If we don't have a version manifest file, but we do have a versions folder,
 				// just add in all folders
 				File versionsFolderFile = new File(versionsFolder.substring(0, versionsFolder.length()-1));
-				for(File f : versionsFolderFile.listFiles()) {
-					if(f.isDirectory()) {
-						if(getJarFile(versionsFolder, f.getName()) != null) {
-							versions.add(f.getName());
+				File[] versionFolderContents = versionsFolderFile.listFiles();
+				
+				// Check if this is null, as this will be null 
+				// in some cases and throw an exception when 
+				// attempting to perform operations on the file
+				if (versionFolderContents != null) {
+					for(File f : versionFolderContents) {
+						if(f.isDirectory()) {
+							if(getJarFile(versionsFolder, f.getName()) != null) {
+								versions.add(f.getName());
+							}
 						}
 					}
 				}

--- a/src/nl/bramstout/mcworldexporter/resourcepack/ResourcePack.java
+++ b/src/nl/bramstout/mcworldexporter/resourcepack/ResourcePack.java
@@ -335,11 +335,14 @@ public class ResourcePack {
 			return versionJar;
 		// If the jar doesn't exist, just pick the first jar file in the versions folder.
 		File[] versionFolderFiles = new File(versionFolder).listFiles();
-		if (versionFolderFiles != null) {
-			for(File f : versionFolderFiles) {
-				if(f.getName().endsWith(".jar"))
-					return f.getPath();
-			}
+		if (versionFolderFiles == null) {
+			// Try adding a "/" to the middle of the path
+			versionFolder = versionsFolder + "/" + versionName;
+			versionFolderFiles = new File(versionFolder).listFiles();
+		}
+		for(File f : versionFolderFiles) {
+			if(f.getName().endsWith(".jar"))
+				return f.getPath();
 		}
 		return null;
 	}


### PR DESCRIPTION
In some cases, paths with MultiMC and forks of MultiMC might have an additional `/` in between `minecraft` and the version folder. This adds a check for if the initial MultiMC path is incorrect and if so, add the `/` to handle it. This also adds extra null checks to avoid null pointer exceptions.

